### PR TITLE
Fix hardcoded localhost:8000 breaking Socket.io and photos on deploy

### DIFF
--- a/client/src/SocketContext.jsx
+++ b/client/src/SocketContext.jsx
@@ -8,8 +8,8 @@ export const SocketProvider = ({ children }) => {
     const [isConnected, setIsConnected] = useState(false);
 
     useEffect(() => {
-        const newSocket = io('http://localhost:8000', {
-            autoConnect: false, 
+        const newSocket = io(import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000', {
+            autoConnect: false,
         });
 
         newSocket.on('connect', () => setIsConnected(true));

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -23,6 +23,8 @@ L.Icon.Default.mergeOptions({
     shadowUrl: markerShadow,
 });
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
 function MapController({ selectedPlaceId, places }) {
     const map = useMap();
     useEffect(() => {
@@ -290,7 +292,7 @@ export const Results = () => {
                     <div className="bg-white rounded-2xl shadow-lg overflow-hidden w-full max-w-lg">
                         {details?.photos?.[0]?.photo_reference && (
                             <img
-                                src={`http://localhost:8000/api/place-photo?ref=${details.photos[0].photo_reference}`}
+                                src={`${API_BASE_URL}/api/place-photo?ref=${details.photos[0].photo_reference}`}
                                 alt={winnerPlace.name}
                                 className="w-full h-52 object-cover"
                             />
@@ -447,7 +449,7 @@ export const Results = () => {
                                                         <>
                                                             {details.photos?.[0]?.photo_reference && (
                                                                 <img
-                                                                    src={`http://localhost:8000/api/place-photo?ref=${details.photos[0].photo_reference}`}
+                                                                    src={`${API_BASE_URL}/api/place-photo?ref=${details.photos[0].photo_reference}`}
                                                                     alt={place.name}
                                                                     className="w-full h-36 object-cover rounded-lg"
                                                                 />
@@ -556,7 +558,7 @@ export const Results = () => {
                                             <Popup className="veto-popup" maxWidth={280} minWidth={240}>
                                                 {placeDetailsMap[place.place_id]?.photos?.[0]?.photo_reference && (
                                                     <img
-                                                        src={`http://localhost:8000/api/place-photo?ref=${placeDetailsMap[place.place_id].photos[0].photo_reference}`}
+                                                        src={`${API_BASE_URL}/api/place-photo?ref=${placeDetailsMap[place.place_id].photos[0].photo_reference}`}
                                                         alt={place.name}
                                                         className="w-full h-32 object-cover"
                                                     />


### PR DESCRIPTION
SocketContext.jsx opened its WebSocket to a hardcoded 'http://localhost:8000' regardless of environment. On any deployed environment (Dev1, Dev, UAT, Prod) the app is served over HTTPS, so the browser blocks the plain-HTTP connection to localhost:8000 (the visitor's own machine, not the backend) as mixed content — this is the "not allowed to request resource" + WebSocket error seen when creating a lobby on Dev1. Worked locally purely because a server happens to be running on localhost:8000 there.

Read the backend URL from VITE_API_BASE_URL (already built and injected per-environment by deploy.yml) with a localhost:8000 fallback for local dev where that var isn't set.

Results.jsx had the same hardcoded URL in three places for the photo proxy (winner screen, expanded restaurant panel, restaurant list) — same fix applied via a shared API_BASE_URL constant.