### PR TITLE
Log Places API error status instead of silently returning empty results

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -645,6 +645,9 @@ async function searchPlaces(selectedOptions, coords) {
 
     try {
         const response = await axios.get(url);
+        if (response.data.status !== 'OK' && response.data.status !== 'ZERO_RESULTS') {
+            console.error('Places API error:', response.data.status, response.data.error_message);
+        }
         return response.data.results;
     } catch (error) {
         console.error('Error searching places:', error);


### PR DESCRIPTION
searchPlaces() called response.data.results directly without checking response.data.status first. Google's Text Search API returns HTTP 200 even on failure (REQUEST_DENIED, OVER_QUERY_LIMIT, etc.) with an empty results array and the real reason in status/error_message — axios only throws on non-2xx, so these failures were invisible. The symptom was the Results page map and restaurant list both silently disappearing (gated on places.length > 0) with nothing in the logs to explain why.

This surfaced three real misconfigurations one at a time while debugging: the API key had referrer restrictions (invalid for server-to-server calls), was restricted to the wrong Places API product (New vs. legacy), and the project's billing account had been closed. All three are Google Cloud Console config, not code — this commit only adds the log line that made them diagnosable.