### PR TITLE
Fix mobile keyboard defaulting to digits-only on PIN entry

### DIFF
--- a/client/src/pages/Join.jsx
+++ b/client/src/pages/Join.jsx
@@ -149,8 +149,9 @@ export const Join = () => {
                                     id="pin"
                                     maxLength={6}
                                     pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                                    inputMode="text"
                                     value={pin}
-                                    onChange={(e) => setPin(e)}
+                                    onChange={(e) => setPin(e.toUpperCase())}
                                 >
                                     <InputOTPGroup className="bg-white">
                                         <InputOTPSlot index={0} />


### PR DESCRIPTION
input-otp defaults inputMode to "numeric" unless explicitly overridden (confirmed in the library's source) — the pattern prop only governs which characters are accepted, not which virtual keyboard mobile browsers show. Since lobby PINs are alphanumeric (A-Z0-9), this made it impossible to type a PIN containing a letter on mobile at all.

Also uppercase the input as it's typed — PINs are always generated uppercase (generateCode() + the server's lobbyCodeSchema regex both require A-Z0-9), but mobile keyboards default to lowercase, so this would have continued failing validation even with the keyboard fixed.

Closes #38