### PR TITLE
Fix lobby routing after leave/re-enter + move Socket.io to app-wide provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,18 @@ npm run dev
 ```
 Runs on `localhost:5173`.
 
+## Deployment
+
+Veto deploys to 4 Azure environments via GitHub Actions:
+
+| Branch | Environment | Trigger |
+|---|---|---|
+| `feature/*` | Dev1 | Auto-deploy on push |
+| `develop` | Dev | Manual approval |
+| `uat` | UAT | Manual approval |
+| `main` | Prod | Manual approval (admins only) |
+
+CI (`ci.yml`) runs lint, build, tests, and security scanning on every push and PR. See [DEPLOYMENT.md](./DEPLOYMENT.md) for full Azure infrastructure setup and the deployment pipeline.
+
 ## Known gaps
-See the "What's NOT Yet Built" section in [CLAUDE.md](./CLAUDE.md) for the current backlog (persistence, auth, mobile layout, deployment, etc.).
+See the "What's NOT Yet Built" section in [CLAUDE.md](./CLAUDE.md) for the current backlog (persistence, auth, mobile layout, etc.).

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,14 +14,16 @@ import { Toaster } from "@/components/ui/toaster";
 const App = () => {
     return (
         <BrowserRouter>
-            <Routes>
-                <Route index element={<Home/>}/>
-                <Route path={"Create"} element={<SocketProvider><Create/></SocketProvider>}/>
-                <Route path={"Join"} element={<SocketProvider><Join/></SocketProvider>}/>
-                <Route path={"Lobby/:code"} element={<SocketProvider><Lobby/></SocketProvider>}/>
-                <Route path={"Questions/:code"} element={<SocketProvider><Questions/></SocketProvider>}/>
-                <Route path={"Results/:code"} element={<SocketProvider><Results/></SocketProvider>}/>
-            </Routes>
+            <SocketProvider>
+                <Routes>
+                    <Route index element={<Home/>}/>
+                    <Route path={"Create"} element={<Create/>}/>
+                    <Route path={"Join"} element={<Join/>}/>
+                    <Route path={"Lobby/:code"} element={<Lobby/>}/>
+                    <Route path={"Questions/:code"} element={<Questions/>}/>
+                    <Route path={"Results/:code"} element={<Results/>}/>
+                </Routes>
+            </SocketProvider>
             <Toaster />
         </BrowserRouter>
     )

--- a/client/src/hooks/useLeaveGuard.js
+++ b/client/src/hooks/useLeaveGuard.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 const PLAYER_LEAVE_MESSAGE =
     "Leave the game? You'll be removed and the others will continue without you.";
@@ -17,9 +17,11 @@ const HOST_LEAVE_MESSAGE =
  */
 export function useLeaveGuard({ socket, code, isHost: isHostProp }) {
     const navigate = useNavigate();
+    const location = useLocation();
     const isHostRef = useRef(isHostProp ?? false);
     const socketRef = useRef(socket);
     const codeRef = useRef(code);
+    const guardPathRef = useRef(location.pathname + location.search);
 
     useEffect(() => {
         if (isHostProp !== undefined) isHostRef.current = isHostProp;
@@ -54,14 +56,19 @@ export function useLeaveGuard({ socket, code, isHost: isHostProp }) {
     }, []);
 
     useEffect(() => {
-        window.history.pushState(null, '', window.location.href);
+        // Pushed through React Router's own navigate (not raw window.history.pushState)
+        // so its internal location/index tracking stays in sync with the real browser
+        // history stack — pushState never fires popstate, so React Router has no way
+        // to observe a raw pushState call, which otherwise silently desyncs its state
+        // and can break subsequent navigate() calls after a leave/re-enter cycle.
+        navigate(guardPathRef.current, { replace: false });
 
         const handlePopState = () => {
             const host = isHostRef.current;
             const confirmed = window.confirm(host ? HOST_LEAVE_MESSAGE : PLAYER_LEAVE_MESSAGE);
 
             if (!confirmed) {
-                window.history.pushState(null, '', window.location.href);
+                navigate(guardPathRef.current, { replace: false });
                 return;
             }
 
@@ -70,6 +77,10 @@ export function useLeaveGuard({ socket, code, isHost: isHostProp }) {
             if (host && sock && lobbyCode) {
                 sock.emit('transferHost', { lobbyCode });
             }
+            // The socket is now shared app-wide (not recreated per route), so leaving
+            // has to disconnect explicitly — otherwise the server never sees a
+            // disconnect event and won't remove this player from lobby.users.
+            sock?.disconnect();
 
             navigate('/', { replace: true });
         };

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -48,10 +48,12 @@ export const Lobby = () => {
         });
 
         socket.on("kicked", () => {
+            socket.disconnect();
             navigate('/', { state: { kicked: true } });
         });
 
         socket.on("hostLeft", () => {
+            socket.disconnect();
             navigate('/', { state: { hostLeft: true } });
         });
 

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -195,7 +195,10 @@ export const Results = () => {
         socket.on('phase_start', handlePhaseStart);
         socket.on('phase_extend', handlePhaseExtend);
         socket.on('restaurantVoteCount', handleVoteCount);
-        const handleHostLeft = () => navigate('/', { state: { hostLeft: true } });
+        const handleHostLeft = () => {
+            socket.disconnect();
+            navigate('/', { state: { hostLeft: true } });
+        };
 
         const handleRemoteCursorMove = ({ user, avatar, x, y }) => {
             setRemoteCursors(prev => ({ ...prev, [user]: { x, y, avatar } }));


### PR DESCRIPTION
## Summary
Fixes #40 — creating a new lobby after leaving a previous one silently failed to
navigate to the Lobby page, even though the server successfully created it.

## Root cause
`useLeaveGuard` pushed its back-button guard entry using raw
`window.history.pushState` instead of React Router's `navigate()`. Since `pushState`
never fires a `popstate` event, React Router had no way to observe it — its internal
location/index tracking silently drifted out of sync with the real browser history
stack. After a leave cycle, later `navigate()` calls (like the one `Create.jsx` fires
on `lobbyCreated`) could fail to actually change the visible route.

## Also fixed: per-route Socket.io provider
While investigating, found the underlying architectural issue that made this bug
possible in the first place: `SocketProvider` was mounted separately per-route
instead of once for the whole app, so every navigation fully disconnected and
recreated the socket. Moved it to wrap the app once.

This changes real behavior the server depends on — leaving a lobby previously
disconnected the socket as a side effect of unmounting the per-route provider, and
that disconnect is what triggers the server to remove the player from `lobby.users`
and hand off host. Added explicit `socket.disconnect()` calls at every real "leaving
a session" point (`useLeaveGuard`'s confirmed leave, and the `kicked`/`hostLeft`
handlers in `Lobby.jsx` and `Results.jsx`) so that server-side cleanup still fires
correctly.

## Testing
- Verified locally: create lobby → leave via back button (confirmed) → create a new
  lobby → correctly routes to `/Lobby/:code`
- Verified on Dev1 after deploy
- `npm run lint` / `npm run build` both clean