### PR TITLE
Fix timer showing 31s instead of 30s due to clock skew

### DIFF
--- a/client/src/pages/Questions.jsx
+++ b/client/src/pages/Questions.jsx
@@ -109,9 +109,10 @@ export const Questions = () => {
             // Clear any running timer
             if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
 
-            // Compute remaining time based on server's startedAt
+            // Compute remaining time based on server's startedAt, clamped in both
+            // directions to guard against clock skew between client and server.
             const elapsed = Math.floor((Date.now() - startedAt) / 1000);
-            const initial = Math.max(0, dur - elapsed);
+            const initial = dur - Math.max(0, Math.min(dur, elapsed));
             setTimeLeft(initial);
 
             timerIntervalRef.current = setInterval(() => {

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -146,8 +146,10 @@ export const Results = () => {
 
             if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
 
+            // Clamp elapsed in both directions to guard against clock skew
+            // between client and server.
             const elapsed = Math.floor((Date.now() - startedAt) / 1000);
-            const initial = Math.max(0, duration - elapsed);
+            const initial = duration - Math.max(0, Math.min(duration, elapsed));
             setTimeLeft(initial);
 
             timerIntervalRef.current = setInterval(() => {


### PR DESCRIPTION
Clamp elapsed time in both directions when computing the initial countdown so client/server clock skew can't push the value above duration (or below 0) in Questions.jsx and Results.jsx. Closes #48