### PR TITLE
Fix sparse restaurant results and improve cuisine query relevance

### DIFF
--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -26,6 +26,23 @@ L.Icon.Default.mergeOptions({
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 
+// Mirrors the server's distanceToRadius ladder in server/index.js so the
+// broadened-search banner can show a human-readable label for the radius
+// actually used.
+const RADIUS_TO_LABEL = {
+    1610: "Walking distance (0-1 miles)",
+    8047: "Short drive (1-5 miles)",
+    24145: "Moderate drive (5-15 miles)",
+    50000: "Long drive (15+ miles)",
+};
+
+function radiusToLabel(radiusMeters) {
+    if (!radiusMeters) return null;
+    if (RADIUS_TO_LABEL[radiusMeters]) return RADIUS_TO_LABEL[radiusMeters];
+    const miles = (radiusMeters / 1609.34).toFixed(1);
+    return `~${miles} miles`;
+}
+
 function MapController({ selectedPlaceId, places }) {
     const map = useMap();
     useEffect(() => {
@@ -100,6 +117,8 @@ export const Results = () => {
     const [phase, setPhase] = useState('voting'); // 'voting' | 'winner'
     const [winnerPlace, setWinnerPlace] = useState(null);
     const [winnerDetails, setWinnerDetails] = useState(null);
+    const [searchBroadened, setSearchBroadened] = useState(false);
+    const [radiusUsed, setRadiusUsed] = useState(null);
 
     const [remoteCursors, setRemoteCursors] = useState({}); // { username: { x, y, avatar } }
 
@@ -123,9 +142,11 @@ export const Results = () => {
     useEffect(() => {
         if (!socket) return;
 
-        const handleGetPlaces = ({ places, coords, lockedPlayers: lp }) => {
+        const handleGetPlaces = ({ places, coords, lockedPlayers: lp, radiusUsed: radius, searchBroadened: broadened }) => {
             setPlaces(places);
             setLoading(false);
+            setRadiusUsed(radius ?? null);
+            setSearchBroadened(Boolean(broadened));
             if (lp) setLockedPlayers(lp);
             if (coords) {
                 const [lat, lng] = coords.split(',').map(Number);
@@ -381,7 +402,7 @@ export const Results = () => {
     // ── Voting screen ─────────────────────────────────────────
     return (
         <Layout user={socket.auth.token} avatar={socket.auth.avatar}>
-            <div className="bg-[#e8f0e8] px-6 pt-4 min-h-screen">
+            <div className="bg-[#e8f0e8] px-6 pt-4 min-h-screen flex flex-col">
 
                 {/* Timer + vote count bar */}
                 <div className="flex w-[90%] lg:w-[80%] mx-auto items-center justify-between py-3">
@@ -397,7 +418,20 @@ export const Results = () => {
                     )}
                 </div>
 
-                <div className="flex w-[90%] lg:w-[80%] mx-auto gap-4 pb-6" style={{ height: 'calc(100vh - 160px)' }}>
+                {searchBroadened && (
+                    <div role="status" className="w-[90%] lg:w-[80%] mx-auto mb-3 px-4 py-2 rounded-lg bg-amber-50 border border-amber-200 text-amber-800 text-sm flex items-start gap-2">
+                        <MapPin className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
+                        <span>
+                            We broadened the search area to find more options
+                            <span className="hidden sm:inline">
+                                {radiusUsed ? ` (now searching within ${radiusToLabel(radiusUsed)})` : ''}
+                            </span>
+                            .
+                        </span>
+                    </div>
+                )}
+
+                <div className="flex w-[90%] lg:w-[80%] mx-auto gap-4 pb-6 flex-1 min-h-0">
 
                     {/* Left: restaurant list with live cursors */}
                     <FollowerPointerCard

--- a/server/index.js
+++ b/server/index.js
@@ -249,6 +249,8 @@ io.on("connection", socket => {
                     places: lobbyObj.places,
                     coords: lobbyObj.coords,
                     lockedPlayers: lobbyObj.lockedPlayers,
+                    radiusUsed: lobbyObj.searchMeta?.radiusUsed,
+                    searchBroadened: lobbyObj.searchMeta?.searchBroadened,
                 });
             }
             const voted = Object.keys(lobbyObj.restaurantVotes).length;
@@ -592,14 +594,17 @@ async function emitGetPlaces(code) {
     if (!lobby) return;
 
     const selectedOptions = getMostVotedOptions(lobby);
-    const places = await searchPlaces(selectedOptions, lobby.coords);
+    const { results: places, radiusUsed, searchBroadened } = await searchPlaces(selectedOptions, lobby.coords);
 
     lobby.places = places;
+    lobby.searchMeta = { radiusUsed, searchBroadened };
 
     io.to(code).emit('getPlaces', {
         places,
         coords: lobby.coords,
         lockedPlayers: lobby.lockedPlayers,
+        radiusUsed,
+        searchBroadened,
     });
 
     console.log('SENT TO RESULTS', places[0]);
@@ -613,17 +618,22 @@ function getMostVotedOptions(lobby) {
     });
 }
 
+const DISTANCE_TO_RADIUS = {
+    "Walking distance (0-1 miles)": 1610,
+    "Short drive (1-5 miles)":      8047,
+    "Moderate drive (5-15 miles)":  24145,
+    "Long drive (15+ miles)":       50000,
+};
+
+// Ordered ladder of tiers used to escalate the search radius when results are sparse.
+const RADIUS_LADDER = [1610, 8047, 24145, 50000];
+
+const MIN_ACCEPTABLE_RESULTS = 5;
+
 async function searchPlaces(selectedOptions, coords) {
     const price    = selectedOptions[1];
     const cuisine  = selectedOptions[2];
     const distance = selectedOptions[3];
-
-    const distanceToRadius = {
-        "Walking distance (0-1 miles)": 1610,
-        "Short drive (1-5 miles)":      8047,
-        "Moderate drive (5-15 miles)":  24145,
-        "Long drive (15+ miles)":       50000,
-    };
 
     const priceToLevel = {
         "$":    1,
@@ -632,27 +642,56 @@ async function searchPlaces(selectedOptions, coords) {
         "$$$$": 4,
     };
 
-    const radius = distanceToRadius[distance] || 8047;
+    const startingRadius = DISTANCE_TO_RADIUS[distance] || 8047;
     const priceLevel = priceToLevel[price];
-    const query = `${cuisine} restaurant`;
+    // Note: Google's Places API `keyword` param is documented for Nearby Search,
+    // not Text Search — Text Search only formally supports `query` as its text
+    // signal, so `keyword` would be silently ignored here. Instead we strengthen
+    // the free-text query itself: leading with the cuisine and pairing it with
+    // "food" (in addition to "restaurant") reinforces the cuisine term relative
+    // to the generic "restaurant" word, biasing relevance ranking toward it.
+    const query = `${cuisine} food restaurant`;
 
-    console.log(`Searching: "${query}" within ${radius}m of ${coords}, price level ${priceLevel}`);
+    let startIndex = RADIUS_LADDER.indexOf(startingRadius);
+    if (startIndex === -1) startIndex = 1;
 
-    let url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(query)}&location=${coords}&radius=${radius}&type=restaurant&key=${process.env.SECRET_KEY}`;
-    if (priceLevel) {
-        url += `&minprice=${priceLevel}&maxprice=${priceLevel}`;
-    }
+    let results = [];
+    let radiusUsed = startingRadius;
+    let searchBroadened = false;
 
-    try {
-        const response = await axios.get(url);
-        if (response.data.status !== 'OK' && response.data.status !== 'ZERO_RESULTS') {
-            console.error('Places API error:', response.data.status, response.data.error_message);
+    for (let i = startIndex; i < RADIUS_LADDER.length; i++) {
+        const radius = RADIUS_LADDER[i];
+        radiusUsed = radius;
+
+        console.log(`Searching: "${query}" within ${radius}m of ${coords}, price level ${priceLevel}`);
+
+        let url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(query)}&location=${coords}&radius=${radius}&type=restaurant&key=${process.env.SECRET_KEY}`;
+        if (priceLevel) {
+            url += `&maxprice=${priceLevel}`;
         }
-        return response.data.results;
-    } catch (error) {
-        console.error('Error searching places:', error);
-        return [];
+
+        try {
+            const response = await axios.get(url);
+            if (response.data.status !== 'OK' && response.data.status !== 'ZERO_RESULTS') {
+                console.error('Places API error:', response.data.status, response.data.error_message);
+                break;
+            }
+
+            results = response.data.results || [];
+
+            if (results.length >= MIN_ACCEPTABLE_RESULTS || i === RADIUS_LADDER.length - 1) {
+                break;
+            }
+
+            // Not enough results yet and there's a larger tier available — broaden and retry.
+            searchBroadened = true;
+        } catch (error) {
+            console.error('Error searching places:', error);
+            return { results: [], radiusUsed, searchBroadened };
+        }
     }
+
+    return { results, radiusUsed, searchBroadened };
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Relax the price filter from an exact match to a ceiling (maxprice only), add radius-broadening when initial search results are sparse, surface a banner when the search area was expanded, and strengthen the Places query text to bias relevance toward the voted cuisine.

Closes #47