### PR TITLE
Fix accessibility issues across client: keyboard focus, ARIA labels, …

### DIFF
--- a/client/src/components/AvatarSelection.jsx
+++ b/client/src/components/AvatarSelection.jsx
@@ -47,13 +47,19 @@ const AvatarSelection = ({ onSelect }) => {
     return (
         <div className="grid grid-cols-4 gap-8 gap-x-14 py-4 mx-auto">
             {Object.entries(avatars).map(([name, src]) => (
-                <img
+                <button
                     key={name}
-                    alt={name}
-                    src={src}
-                    className="rounded-full h-10 w-10 cursor-pointer"
+                    type="button"
+                    aria-label={`Select ${name} avatar`}
+                    className="rounded-full h-10 w-10 cursor-pointer p-0 border-0 bg-transparent"
                     onClick={() => onSelect(src)}
-                />
+                >
+                    <img
+                        alt={name}
+                        src={src}
+                        className="rounded-full h-10 w-10"
+                    />
+                </button>
             ))}
         </div>
     );

--- a/client/src/components/ui/background-ripple-effect.jsx
+++ b/client/src/components/ui/background-ripple-effect.jsx
@@ -30,6 +30,7 @@ export const BackgroundRippleEffect = ({
   return (
     <div
       ref={ref}
+      aria-hidden="true"
       className={cn(
         "absolute inset-0 h-full w-full overflow-hidden",
         "[--cell-border-color:rgba(26,46,26,0.28)] [--cell-fill-color:rgba(26,46,26,0.10)] [--cell-shadow-color:rgba(45,106,45,0.35)]",

--- a/client/src/components/ui/glowing-effect.jsx
+++ b/client/src/components/ui/glowing-effect.jsx
@@ -100,6 +100,7 @@ const GlowingEffect = memo(({
   return (
     <>
       <div
+        aria-hidden="true"
         className={cn(
           "pointer-events-none absolute -inset-px hidden rounded-[inherit] border opacity-0 transition-opacity",
           glow && "opacity-100",
@@ -107,6 +108,7 @@ const GlowingEffect = memo(({
           disabled && "!block"
         )} />
       <div
+        aria-hidden="true"
         ref={containerRef}
         style={
           {

--- a/client/src/constants/strings.js
+++ b/client/src/constants/strings.js
@@ -57,6 +57,8 @@ export const strings = {
             errorTitle: "Error",
             errorCopyDescription: "Failed to copy PIN to clipboard. Try again.",
             hostBadge: "Host",
+            copyPinLabel: "Copy room PIN",
+            kickPlayerLabel: (name) => `Kick ${name}`,
         },
         questions: {
             newHostTitle: "New host",
@@ -166,6 +168,8 @@ export const strings = {
             errorTitle: "Error",
             errorCopyDescription: "No se pudo copiar el PIN al portapapeles. Inténtalo de nuevo.",
             hostBadge: "Anfitrión",
+            copyPinLabel: "Copiar PIN de sala",
+            kickPlayerLabel: (name) => `Expulsar a ${name}`,
         },
         questions: {
             newHostTitle: "Nuevo anfitrión",
@@ -275,6 +279,8 @@ export const strings = {
             errorTitle: "Erreur",
             errorCopyDescription: "Échec de la copie du code dans le presse-papiers. Réessayez.",
             hostBadge: "Hôte",
+            copyPinLabel: "Copier le code de la salle",
+            kickPlayerLabel: (name) => `Exclure ${name}`,
         },
         questions: {
             newHostTitle: "Nouvel hôte",
@@ -384,6 +390,8 @@ export const strings = {
             errorTitle: "Errore",
             errorCopyDescription: "Impossibile copiare il PIN negli appunti. Riprova.",
             hostBadge: "Host",
+            copyPinLabel: "Copia PIN della stanza",
+            kickPlayerLabel: (name) => `Espelli ${name}`,
         },
         questions: {
             newHostTitle: "Nuovo host",
@@ -493,6 +501,8 @@ export const strings = {
             errorTitle: "Erro",
             errorCopyDescription: "Falha ao copiar o PIN para a área de transferência. Tente novamente.",
             hostBadge: "Anfitrião",
+            copyPinLabel: "Copiar PIN da sala",
+            kickPlayerLabel: (name) => `Expulsar ${name}`,
         },
         questions: {
             newHostTitle: "Novo anfitrião",
@@ -602,6 +612,8 @@ export const strings = {
             errorTitle: "Ошибка",
             errorCopyDescription: "Не удалось скопировать PIN в буфер обмена. Попробуйте снова.",
             hostBadge: "Хост",
+            copyPinLabel: "Скопировать PIN комнаты",
+            kickPlayerLabel: (name) => `Исключить ${name}`,
         },
         questions: {
             newHostTitle: "Новый хост",

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -11,7 +11,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select"
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { useLanguage, useStrings } from "@/context/LanguageContext";
@@ -31,6 +31,14 @@ export const Home = () => {
     const { toast } = useToast();
     const { language, setLanguage } = useLanguage();
     const t = useStrings();
+    const reducedMotion = useReducedMotion();
+    // All entrance animations on this page share the same delay/duration/ease,
+    // just with different initial offsets, so compute the transition once.
+    const entranceTransition = {
+        delay: reducedMotion ? 0 : 0.3,
+        duration: reducedMotion ? 0 : 0.8,
+        ease: "easeInOut",
+    };
 
     useEffect(() => {
         if (location.state?.kicked) {
@@ -54,13 +62,9 @@ export const Home = () => {
         <div className="flex flex-col h-screen">
             <div className="flex justify-end p-8">
                 <motion.div
-                    initial={{opacity: 0.0, x: 40}}
+                    initial={reducedMotion ? false : {opacity: 0.0, x: 40}}
                     whileInView={{opacity: 1, x: 0}}
-                    transition={{
-                        delay: 0.3,
-                        duration: 0.8,
-                        ease: "easeInOut",
-                    }}
+                    transition={entranceTransition}
                 >
                     <Select value={language} onValueChange={setLanguage}>
                         <SelectTrigger className="flex border-0 hover:shadow-md w-fit" aria-label={t.home.languageLabel}>
@@ -95,13 +99,9 @@ export const Home = () => {
                 <div className="-mt-56">
                     <div className="w-full flex justify-center">
                         <motion.div
-                            initial={{opacity: 0.0, y: 40}}
+                            initial={reducedMotion ? false : {opacity: 0.0, y: 40}}
                             whileInView={{opacity: 1, y: 0}}
-                            transition={{
-                                delay: 0.3,
-                                duration: 0.8,
-                                ease: "easeInOut",
-                            }}
+                            transition={entranceTransition}
                         >
                             <img src="/veto-logo.png" alt="Veto" className="w-64" />
                         </motion.div>
@@ -111,13 +111,9 @@ export const Home = () => {
                     <div className="flex flex-col space-y-4">
                         <Link to={"/Create"}>
                             <motion.div
-                                initial={{opacity: 0.0, y: 40}}
+                                initial={reducedMotion ? false : {opacity: 0.0, y: 40}}
                                 whileInView={{opacity: 1, y: 0}}
-                                transition={{
-                                    delay: 0.3,
-                                    duration: 0.8,
-                                    ease: "easeInOut",
-                                }}
+                                transition={entranceTransition}
                             >
                                 <Button className="min-w-40 px-6 text-white">
                                     {t.home.create}
@@ -127,13 +123,9 @@ export const Home = () => {
                         </Link>
                         <Link to={"/Join"}>
                             <motion.div
-                                initial={{opacity: 0.0, y: 40}}
+                                initial={reducedMotion ? false : {opacity: 0.0, y: 40}}
                                 whileInView={{opacity: 1, y: 0}}
-                                transition={{
-                                    delay: 0.3,
-                                    duration: 0.8,
-                                    ease: "easeInOut",
-                                }}
+                                transition={entranceTransition}
                             >
                                 <Button className="min-w-40 px-6 text-white">
                                     {t.home.join}

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -4,7 +4,7 @@ import { Footer } from "@/components/Footer";
 import { useSocket } from "@/SocketContext";
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { useToast } from "@/hooks/use-toast"
 import { useLeaveGuard } from "@/hooks/useLeaveGuard";
 import { useStrings } from "@/context/LanguageContext";
@@ -20,6 +20,7 @@ export const Lobby = () => {
     const navigate = useNavigate();
     const { toast } = useToast();
     const t = useStrings();
+    const reducedMotion = useReducedMotion();
 
     const [users, setUsers] = useState([]);
     const [lobbyCode, setLobbyCode] = useState('');
@@ -213,11 +214,11 @@ export const Lobby = () => {
             </div>
 
             <motion.div
-                initial={{ opacity: 0.0, y: 0 }}
+                initial={reducedMotion ? false : { opacity: 0.0, y: 0 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 transition={{
-                    delay: 0.3,
-                    duration: 0.95,
+                    delay: reducedMotion ? 0 : 0.3,
+                    duration: reducedMotion ? 0 : 0.95,
                     ease: "easeInOut",
                 }}
             >
@@ -227,13 +228,18 @@ export const Lobby = () => {
                     </h6>
                     <h1 className="flex items-left text-4xl font-bold text-white tracking-wider">
                         {lobbyCode || t.lobby.loading}
-                        <Copy className={"ml-2 cursor-pointer"}
+                        <button
+                            type="button"
+                            aria-label={t.lobby.copyPinLabel}
+                            className="ml-2 cursor-pointer bg-transparent border-0 p-0 inline-flex items-center"
                             onClick={() => {
                                 if (lobbyCode) {
                                     handleCopyPin();
                                 }
                             }}
-                        />
+                        >
+                            <Copy />
+                        </button>
                     </h1>
                 </div>
             </motion.div>
@@ -327,9 +333,9 @@ export const Lobby = () => {
                                         else cardRefs.current.delete(displayName);
                                     }}
                                     key={displayName + index}
-                                    initial={{ opacity: 0, scale: 0.95 }}
+                                    initial={reducedMotion ? false : { opacity: 0, scale: 0.95 }}
                                     animate={{ opacity: 1, scale: 1 }}
-                                    transition={{ duration: 0.28, delay: index * 0.04 }}
+                                    transition={{ duration: reducedMotion ? 0 : 0.28, delay: reducedMotion ? 0 : index * 0.04 }}
                                     layout
                                 >
                                     <div className="relative rounded-xl">
@@ -344,8 +350,10 @@ export const Lobby = () => {
                                         <div className="relative flex items-center space-x-4 bg-white/80 dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow group">
                                             {isHost && userName !== socket?.auth?.token && (
                                                 <button
+                                                    type="button"
                                                     onClick={() => handleKick(displayName)}
-                                                    className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                                                    aria-label={t.lobby.kickPlayerLabel(displayName)}
+                                                    className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                 >
                                                     <XCircle className="w-6 h-6 text-white fill-red-500" />
                                                 </button>

--- a/client/src/pages/Questions.jsx
+++ b/client/src/pages/Questions.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { Layout } from "./Layout.jsx"
 import { useParams, useNavigate } from "react-router-dom";
 import { Button, Card } from "flowbite-react";
@@ -61,6 +61,7 @@ export const Questions = () => {
     const navigate = useNavigate();
     const { toast } = useToast();
     const t = useStrings();
+    const reducedMotion = useReducedMotion();
 
     useLeaveGuard({ socket, code });
 
@@ -188,9 +189,9 @@ export const Questions = () => {
 
             <motion.div
                 className={"w-full lg:w-[80%] bg-[#f0f7f0] rounded-xl mx-auto p-8 shadow-sm"}
-                initial={{ opacity: 0, y: 10 }}
+                initial={reducedMotion ? false : { opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.99, ease: "easeOut" }}
+                transition={{ duration: reducedMotion ? 0 : 0.99, ease: "easeOut" }}
             >
                 {poll && (
                     <>

--- a/client/src/pages/Results.jsx
+++ b/client/src/pages/Results.jsx
@@ -6,7 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { MapPin, Clock, Phone, Globe, ExternalLink, ChevronDown, ChevronUp, Timer, Trophy, LogOut } from "lucide-react";
 import { FollowerPointerCard } from "@/components/ui/following-pointer";
-import { AnimatePresence, motion, useMotionValue, useSpring } from "motion/react";
+import { AnimatePresence, motion, useMotionValue, useReducedMotion, useSpring } from "motion/react";
 import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -198,7 +198,7 @@ function RemoteCursor({ user, avatar, x, y }) {
                 <path d="M14.082 2.182a.5.5 0 0 1 .103.557L8.528 15.467a.5.5 0 0 1-.917-.007L5.57 10.694.803 8.652a.5.5 0 0 1-.006-.916l12.728-5.657a.5.5 0 0 1 .556.103z" />
             </svg>
             <div className="ml-4 -mt-1 flex items-center gap-1.5 bg-[#1a2e1a] text-white text-xs font-semibold px-2 py-1 rounded-full whitespace-nowrap shadow">
-                {avatar && <img src={avatar} alt="" className="w-4 h-4 rounded-full object-cover" />}
+                {avatar && <img src={avatar} alt="" aria-hidden="true" className="w-4 h-4 rounded-full object-cover" />}
                 <span>{user}</span>
             </div>
         </motion.div>
@@ -211,6 +211,7 @@ export const Results = () => {
     const navigate = useNavigate();
     const { toast } = useToast();
     const t = useStrings();
+    const reducedMotion = useReducedMotion();
 
     const [isHost, setIsHost] = useState(false);
 
@@ -671,9 +672,9 @@ export const Results = () => {
                                     return (
                                         <motion.div
                                             key={place.place_id}
-                                            initial={{ opacity: 0, y: 10 }}
+                                            initial={reducedMotion ? false : { opacity: 0, y: 10 }}
                                             animate={{ opacity: 1, y: 0 }}
-                                            transition={{ duration: 0.3, ease: "easeOut", delay: index * 0.04 }}
+                                            transition={{ duration: reducedMotion ? 0 : 0.3, ease: "easeOut", delay: reducedMotion ? 0 : index * 0.04 }}
                                             className={`rounded-xl border shadow-sm hover:shadow-md transition-shadow overflow-hidden ${hasVotedThis ? 'border-[#2d6a2d] bg-[#e8f0e8]' : 'border-[#c8dcc8] bg-white'}`}
                                         >
                                             <div
@@ -692,9 +693,9 @@ export const Results = () => {
 
                                             {isExpanded && (
                                                 <motion.div
-                                                    initial={{ opacity: 0, y: 10 }}
+                                                    initial={reducedMotion ? false : { opacity: 0, y: 10 }}
                                                     animate={{ opacity: 1, y: 0 }}
-                                                    transition={{ duration: 0.25, ease: "easeOut" }}
+                                                    transition={{ duration: reducedMotion ? 0 : 0.25, ease: "easeOut" }}
                                                     className="px-5 pb-5 bg-white space-y-3 border-t border-[#c8dcc8] pt-3"
                                                 >
                                                     {isLoadingDetails ? (


### PR DESCRIPTION
…reduced motion

Address kick/copy-PIN buttons and avatar selection being keyboard-inaccessible, hide purely decorative glow/ripple effects from screen readers, and respect prefers-reduced-motion on entrance animations in Lobby, Questions, Results, and Home.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

This is just a draft for your review — I have not run git commit. If you want me to commit it, say so explicitly.

How to manually verify the ADA/accessibility fixes

1. Keyboard navigation (Priority 1 items)
- Run the app (npm run dev in client/), open a lobby as host with at least one other player.
- Press Tab repeatedly through the page — confirm you can reach:
  - The PIN copy button (now a real <button>) — press Enter/Space to activate, confirm the "PIN Copied" toast fires.
  - Each player card's kick button — it should become visible (not just on hover) when focused, and show a focus ring; confirm Enter/Space triggers the kick.
- On the avatar-selection screen (Create/Join flow), Tab through avatars and press Enter/Space to select one — confirm selection works without a mouse.

2. Screen reader spot-check
- macOS: enable VoiceOver (Cmd+F5), navigate through Lobby with VO+Right Arrow.
  - Confirm the kick button announces "Kick {name}, button" and the copy button announces "Copy room PIN, button".
  - Confirm the decorative glow/ripple background effects are silently skipped (not announced as generic groups/images).
  - Confirm the remote cursor avatar in Results isn't announced as an unlabeled image.
- Windows: NVDA (free) is a good alternative if you don't have a Mac.

3. prefers-reduced-motion
- macOS: System Settings → Accessibility → Display → enable "Reduce motion".
- Reload Home, Lobby, Questions, and Results — the fade/slide entrance animations should now appear instantly (no animation) rather than transitioning in.
- You can also simulate this in Chrome DevTools: Cmd+Shift+P → "Show Rendering" → "Emulate CSS media feature prefers-reduced-motion: reduce" — no OS setting change needed.