### PR TITLE
Show toast when joining a nonexistent lobby fails

### DIFF
--- a/client/src/constants/strings.js
+++ b/client/src/constants/strings.js
@@ -41,6 +41,8 @@ export const strings = {
             namePlaceholder: "Neo",
             pinLabel: "Pin",
             joinButton: "Join host",
+            errorTitle: "Lobby not found",
+            errorDescription: "The lobby code is invalid or the game has already ended. Check the code and try again.",
         },
         lobby: {
             start: "Start",
@@ -152,6 +154,8 @@ export const strings = {
             namePlaceholder: "Neo",
             pinLabel: "Pin",
             joinButton: "Unirse al anfitrión",
+            errorTitle: "Sala no encontrada",
+            errorDescription: "El código de sala no es válido o la partida ya finalizó. Revisa el código e inténtalo de nuevo.",
         },
         lobby: {
             start: "Comenzar",
@@ -263,6 +267,8 @@ export const strings = {
             namePlaceholder: "Neo",
             pinLabel: "Code",
             joinButton: "Rejoindre l'hôte",
+            errorTitle: "Salle introuvable",
+            errorDescription: "Le code de la salle est invalide ou la partie est déjà terminée. Vérifiez le code et réessayez.",
         },
         lobby: {
             start: "Démarrer",
@@ -374,6 +380,8 @@ export const strings = {
             namePlaceholder: "Neo",
             pinLabel: "Pin",
             joinButton: "Unisciti all'host",
+            errorTitle: "Stanza non trovata",
+            errorDescription: "Il codice della stanza non è valido o la partita è già terminata. Controlla il codice e riprova.",
         },
         lobby: {
             start: "Inizia",
@@ -485,6 +493,8 @@ export const strings = {
             namePlaceholder: "Neo",
             pinLabel: "Pin",
             joinButton: "Entrar no anfitrião",
+            errorTitle: "Sala não encontrada",
+            errorDescription: "O código da sala é inválido ou o jogo já terminou. Verifique o código e tente novamente.",
         },
         lobby: {
             start: "Iniciar",
@@ -596,6 +606,8 @@ export const strings = {
             namePlaceholder: "Нео",
             pinLabel: "Пин-код",
             joinButton: "Присоединиться к хосту",
+            errorTitle: "Лобби не найдено",
+            errorDescription: "Код лобби неверен или игра уже завершена. Проверьте код и попробуйте снова.",
         },
         lobby: {
             start: "Начать",

--- a/client/src/pages/Join.jsx
+++ b/client/src/pages/Join.jsx
@@ -33,6 +33,7 @@ import { useSocket } from "@/SocketContext";
 import { useEffect } from "react";
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp";
 import { useStrings } from "@/context/LanguageContext";
+import { useToast } from "@/hooks/use-toast";
 
 
 export const Join = () => {
@@ -42,6 +43,7 @@ export const Join = () => {
     const navigate = useNavigate();
     const { socket, connectSocket } = useSocket();
     const t = useStrings();
+    const { toast } = useToast();
 
 
     const avatarSelect = (avatar) => {
@@ -53,11 +55,21 @@ export const Join = () => {
         const handleLobbyJoined = () => {
             navigate(`/Lobby/${pin}`);
         };
+        const handleError = () => {
+            toast({
+                title: t.join.errorTitle,
+                description: t.join.errorDescription,
+                variant: "destructive",
+                duration: 4000,
+            });
+        };
         socket.on('lobbyJoined', handleLobbyJoined);
+        socket.on('Error', handleError);
         return () => {
             socket.off('lobbyJoined', handleLobbyJoined);
+            socket.off('Error', handleError);
         }
-    }, [socket, pin, navigate]);
+    }, [socket, pin, navigate, toast, t]);
 
     const handleJoin = () => {
         console.log("name: ", name);

--- a/server/index.js
+++ b/server/index.js
@@ -214,7 +214,7 @@ io.on("connection", socket => {
 
     socket.on("joinLobby", withValidation(socket, schemas.joinLobby, ({ lobbyCode }) => {
         const lobbyObj = lobbies[lobbyCode];
-        if (!lobbyObj) return socket.emit('Error', 'Error with joinLobby');
+        if (!lobbyObj) return socket.emit('Error', 'Lobby not found');
 
         socket.join(lobbyCode);
         if (!lobbyObj.users.some(u => u.name === socket.data.user)) {


### PR DESCRIPTION
Join.jsx silently dropped the server's 'Error' event when a lobby code didn't match an active lobby, leaving users with no feedback. Add a destructive toast (with translated strings for all supported languages) and clarify the server-side error message for logging.

Closes #65